### PR TITLE
Only block up/down default while autocomplete is open

### DIFF
--- a/dist/Autosuggest.js
+++ b/dist/Autosuggest.js
@@ -524,9 +524,9 @@ var Autosuggest = (function(_Component) {
                     newValue,
                     keyCode === 40 ? 'down' : 'up'
                   );
-                }
 
-                event.preventDefault(); // Prevents the cursor from moving
+                  event.preventDefault(); // Prevents the cursor from moving
+                }
 
                 _this2.justPressedUpDown = true;
 

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -569,9 +569,9 @@ export default class Autosuggest extends Component {
                 newValue,
                 keyCode === 40 ? 'down' : 'up'
               );
-            }
 
-            event.preventDefault(); // Prevents the cursor from moving
+              event.preventDefault(); // Prevents the cursor from moving
+            }
 
             this.justPressedUpDown = true;
 


### PR DESCRIPTION
Another change that's necessary to use this well in textareas. This library was blocking the default action of up/down arrow keys ALL THE TIME, not just when the autosuggest was open. The change makes it so it only blocks the default when the autosuggest is open.