### PR TITLE
Only highlight first item when suggestions are first revealed

### DIFF
--- a/dist/Autosuggest.js
+++ b/dist/Autosuggest.js
@@ -152,16 +152,8 @@ var Autosuggest = (function(_Component) {
       key: 'componentWillReceiveProps',
       value: function componentWillReceiveProps(nextProps) {
         if (
-          (0, _arrays2.default)(nextProps.suggestions, this.props.suggestions)
+          !(0, _arrays2.default)(nextProps.suggestions, this.props.suggestions)
         ) {
-          if (
-            nextProps.highlightFirstSuggestion &&
-            nextProps.suggestions.length > 0 &&
-            this.justPressedUpDown === false
-          ) {
-            this.highlightFirstSuggestion();
-          }
-        } else {
           if (this.willRenderSuggestions(nextProps)) {
             if (nextProps.highlightFirstSuggestion) {
               this.highlightFirstSuggestion();

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -117,15 +117,7 @@ export default class Autosuggest extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (shallowEqualArrays(nextProps.suggestions, this.props.suggestions)) {
-      if (
-        nextProps.highlightFirstSuggestion &&
-        nextProps.suggestions.length > 0 &&
-        this.justPressedUpDown === false
-      ) {
-        this.highlightFirstSuggestion();
-      }
-    } else {
+    if (!shallowEqualArrays(nextProps.suggestions, this.props.suggestions)) {
       if (this.willRenderSuggestions(nextProps)) {
         if (nextProps.highlightFirstSuggestion) {
           this.highlightFirstSuggestion();


### PR DESCRIPTION
I have no idea why this code was here, it causes the first item to be re-selected on every change in props to the autosuggest component. But props can change for many reasons that are totally unrelated to the suggestions beind revealed, so we don't want this behavior. This was causing the first item to be re-highlighted on every save of snippet items, which was annoying and could cause you to choose the wrong thing if it happened just before you accepted the suggestion.